### PR TITLE
[Fix] To-Do 추가 모달 배경 색상 수정 (#62)

### DIFF
--- a/src/components/schedule/TodoCard.vue
+++ b/src/components/schedule/TodoCard.vue
@@ -786,5 +786,65 @@ const deleteTodo = async () => {
   }
 }
 
+/* ===== 항상 화이트모드 고정 (배경은 어둡게 유지) ===== */
+.modal-overlay {
+  background: rgba(0, 0, 0, 0.35) !important; /* ✅ 반투명 어두운 배경 유지 */
+}
+
+.modal-box,
+.confirm-box,
+.add-modal,
+.edit-modal {
+  background: #ffffff !important; /* 모달 내부는 흰색 */
+  color: #000000 !important; /* 글자는 검정 */
+}
+
+.input-box {
+  background: #ffffff !important;
+  color: #000000 !important;
+  border: 1px solid #ddd !important;
+}
+
+.input-box::placeholder {
+  color: #999 !important;
+}
+
+.label,
+.bookmark-title,
+.bookmark-item,
+.confirm-title,
+.confirm-text {
+  color: #222 !important;
+}
+
+.bookmark-item {
+  background: #fafafa !important;
+}
+
+.bookmark-item:hover {
+  background: #fff3c4 !important;
+}
+
+.modal-footer .cancel {
+  background: #e0e0e0 !important;
+  color: #333 !important;
+}
+
+.modal-footer .confirm {
+  background: #f5c518 !important;
+  color: #000 !important;
+}
+
+.confirm-actions .cancel {
+  background: #e0e0e0 !important;
+  color: #000 !important;
+}
+
+.confirm-actions .danger {
+  background: #ff5858 !important;
+  color: #fff !important;
+}
+
+
 
 </style>


### PR DESCRIPTION
### 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
To-Do 추가 모달 배경 색상 수정 (화이트 배경 → 반투명 어두운 배경)
<br/>


### 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- To-Do 추가 모달창 배경이 흰색으로 전체 화면을 덮는 문제 수정
- `.modal-overlay`의 background를 `rgba(0,0,0,0.35)`로 변경
- 모달 본체(`.modal-box`, `.add-modal` 등)는 기존 화이트모드 디자인 유지
<br/>


### 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
 #62 
<br/>


### 💻 테스트 화면
<!-- 구현된 화면이 있다면 이미지를 첨부해주세요 -->
<img width="1919" height="972" alt="image" src="https://github.com/user-attachments/assets/b64e607f-7199-4dbd-9f8b-394bd01cb900" />

<br/>


### ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  

<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.
