### PR TITLE
Refactor: 프로젝트 문서함에서 스톤문서함으로 갈 때 이름이 바뀌지 않는 문제 해결

### DIFF
--- a/src/views/Drive/DriveMain.vue
+++ b/src/views/Drive/DriveMain.vue
@@ -2356,9 +2356,7 @@ export default {
             this.currentRootType !== rootType || this.currentRootId !== rootId
           );
 
-          this.currentRootType = rootType;
-          this.currentRootId = rootId;
-
+          // 루트가 변경되면 먼저 이름을 업데이트한 후 currentRootType/currentRootId 업데이트
           if (isRootChanged || !this.rootName) {
             try {
               const nameResponse = await driveService.getRootName(rootType, rootId);
@@ -2368,6 +2366,9 @@ export default {
               this.rootName = null;
             }
           }
+
+          this.currentRootType = rootType;
+          this.currentRootId = rootId;
         }
         
         // folderId가 있으면 해당 폴더의 내용 로드
@@ -2476,7 +2477,9 @@ export default {
           }
           
           // 브레드크럼 업데이트
-          if (folderId || items.length > 0) {
+          // folderId가 null이면 루트로 이동한 것이므로 항상 업데이트
+          // folderId가 있거나 items가 있으면 업데이트
+          if (!folderId || folderId === 'root' || items.length > 0) {
             this.updateBreadcrumbs(folderId, items, rootType || this.currentRootType);
           }
           


### PR DESCRIPTION
### 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
프로젝트 문서함에서 스톤문서함으로 갈 때 이름이 바뀌지 않는 문제 해결
<br/>


### 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
프로젝트 문서함에서 스톤문서함으로 갈 때 이름이 바뀌지 않는 문제 해결
<br/>


### 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
 close #191 
<br/>


### 💻 테스트 화면
<!-- 구현된 화면이 있다면 이미지를 첨부해주세요 -->

<br/>


### ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  

<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.
